### PR TITLE
Running synchronous processes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 RunECS is a tool for running one-off processes in an ECS cluster. The tool was created as a simple solution for occasional running of processes in the ECS cluster - e.g. various data migrations. Currently only the FARGATE launch type is supported.
 
+The process can be started asynchronously (does not wait for finish) or synchronously with the `-w` parameter (waits for task finish).
+
 ## How to Use
 
 The ECS cluster settings are located in the `~/.runecs.yml` file, which is located in the user's home directory. The default profile is called `default` and is automatically used unless explicitly specified otherwise.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -26,8 +26,9 @@ import (
 )
 
 var (
-	profile string
-	verbose bool
+	profile  string
+	verbose  bool
+	execWait bool
 )
 
 var runCmd = &cobra.Command{
@@ -36,7 +37,7 @@ var runCmd = &cobra.Command{
 	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		svc := initService()
-		svc.Execute(args)
+		svc.Execute(args, execWait)
 	},
 }
 
@@ -57,6 +58,8 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&profile, "profile", "p", "default", "profile name with ECS cluster settings")
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "", false, "verbose output")
 	rootCmd.CompletionOptions.DisableDefaultCmd = true
+
+	runCmd.PersistentFlags().BoolVarP(&execWait, "wait", "w", false, "wait for the task to finish")
 
 	rootCmd.AddCommand(runCmd)
 	rootCmd.AddCommand(deregisterCmd)


### PR DESCRIPTION
Using the `-w` / `--wait` parameter, it waits for the task to finish. Example

```shell
runecs run rake db:migrate --wait
```