### PR TITLE
AWS profiles support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,25 +33,7 @@ Pre-compiled binaries for all platforms are available on our [releases page](htt
 
 ### AWS Credentials
 
-RunECS supports multiple methods for AWS authentication:
-
-#### Using Environment Variables
-
-AWS credential configuration through environment variables is also supported as documented in the [AWS CLI Environment Variables guide](https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-envvars.html). This approach integrates seamlessly with tools like [direnv](https://direnv.net/), enabling distinct AWS account configurations, regions, and other settings to be maintained on a per-directory or per-project basis.
-
-#### Using AWS Credential Profiles
-
-AWS credential profiles can be specified using the global `--profile` parameter, allowing you to easily switch between different AWS accounts or roles. Profiles are configured in the AWS credentials file as documented in the [AWS CLI Configuration Files guide](https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-files.html).
-
-```bash
-# Use a specific AWS profile
-runecs list --profile production
-
-# Deploy using a different profile
-runecs deploy --service myapp/web -i latest --profile staging
-```
-
-The credentials file is typically located at `~/.aws/credentials`.
+RunECS supports multiple methods for AWS authentication. See [AWS Authentication](docs/aws-authentication.md) for detailed configuration options.
 
 ## Key Features
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,25 @@ Pre-compiled binaries for all platforms are available on our [releases page](htt
 
 ### AWS Credentials
 
-AWS credential configuration through environment variables is supported as documented in the [AWS CLI Environment Variables guide](https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-envvars.html). This approach integrates seamlessly with tools like [direnv](https://direnv.net/), enabling distinct AWS account configurations, regions, and other settings to be maintained on a per-directory or per-project basis. Multiple AWS environments can be managed effectively without the need for constant profile switching.
+RunECS supports multiple methods for AWS authentication:
+
+#### Using Environment Variables
+
+AWS credential configuration through environment variables is also supported as documented in the [AWS CLI Environment Variables guide](https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-envvars.html). This approach integrates seamlessly with tools like [direnv](https://direnv.net/), enabling distinct AWS account configurations, regions, and other settings to be maintained on a per-directory or per-project basis.
+
+#### Using AWS Credential Profiles
+
+AWS credential profiles can be specified using the global `--profile` parameter, allowing you to easily switch between different AWS accounts or roles. Profiles are configured in the AWS credentials file as documented in the [AWS CLI Configuration Files guide](https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-files.html).
+
+```bash
+# Use a specific AWS profile
+runecs list --profile production
+
+# Deploy using a different profile
+runecs deploy --service myapp/web -i latest --profile staging
+```
+
+The credentials file is typically located at `~/.aws/credentials`.
 
 ## Key Features
 

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -44,7 +44,7 @@ func deployHandler(dockerImageTag *string) func(*cobra.Command, []string) {
 		defer cancel()
 
 		profile := rootCmd.Flag("profile").Value.String()
-		clients, err := ecs.NewAWSClients(profile)
+		clients, err := ecs.NewAWSClients(ctx, profile)
 		if err != nil {
 			log.Fatalf("Failed to initialize AWS clients: %v\n", err)
 		}

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -43,7 +43,8 @@ func deployHandler(dockerImageTag *string) func(*cobra.Command, []string) {
 		ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 		defer cancel()
 
-		clients, err := ecs.NewAWSClients()
+		profile := rootCmd.Flag("profile").Value.String()
+		clients, err := ecs.NewAWSClients(profile)
 		if err != nil {
 			log.Fatalf("Failed to initialize AWS clients: %v\n", err)
 		}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -33,7 +33,8 @@ func listHandler(cmd *cobra.Command, args []string) error {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
 
-	clients, err := ecs.NewAWSClients()
+	profile := rootCmd.Flag("profile").Value.String()
+	clients, err := ecs.NewAWSClients(profile)
 	if err != nil {
 		return fmt.Errorf("failed to initialize AWS clients: %w", err)
 	}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -34,7 +34,7 @@ func listHandler(cmd *cobra.Command, args []string) error {
 	defer cancel()
 
 	profile := rootCmd.Flag("profile").Value.String()
-	clients, err := ecs.NewAWSClients(profile)
+	clients, err := ecs.NewAWSClients(ctx, profile)
 	if err != nil {
 		return fmt.Errorf("failed to initialize AWS clients: %w", err)
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -50,6 +50,7 @@ var rootCmd = &cobra.Command{
 func init() {
 	rootCmd.CompletionOptions.DisableDefaultCmd = true
 	rootCmd.PersistentFlags().String("service", "", "service name (cluster/service)")
+	rootCmd.PersistentFlags().String("profile", "", "AWS profile to use for credentials")
 }
 
 func parseServiceFlag() (cluster, service string) {

--- a/cmd/prune.go
+++ b/cmd/prune.go
@@ -37,7 +37,7 @@ func pruneHandler(cmd *cobra.Command, args []string) {
 	defer cancel()
 
 	profile := rootCmd.Flag("profile").Value.String()
-	clients, err := ecs.NewAWSClients(profile)
+	clients, err := ecs.NewAWSClients(ctx, profile)
 	if err != nil {
 		log.Fatalf("Failed to initialize AWS clients: %v\n", err)
 	}

--- a/cmd/prune.go
+++ b/cmd/prune.go
@@ -36,7 +36,8 @@ func pruneHandler(cmd *cobra.Command, args []string) {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
 
-	clients, err := ecs.NewAWSClients()
+	profile := rootCmd.Flag("profile").Value.String()
+	clients, err := ecs.NewAWSClients(profile)
 	if err != nil {
 		log.Fatalf("Failed to initialize AWS clients: %v\n", err)
 	}

--- a/cmd/restart.go
+++ b/cmd/restart.go
@@ -33,7 +33,7 @@ func restartHandler(cmd *cobra.Command, args []string) {
 	defer cancel()
 
 	profile := rootCmd.Flag("profile").Value.String()
-	clients, err := ecs.NewAWSClients(profile)
+	clients, err := ecs.NewAWSClients(ctx, profile)
 	if err != nil {
 		log.Fatalf("Failed to initialize AWS clients: %v\n", err)
 	}

--- a/cmd/restart.go
+++ b/cmd/restart.go
@@ -32,7 +32,8 @@ func restartHandler(cmd *cobra.Command, args []string) {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
 
-	clients, err := ecs.NewAWSClients()
+	profile := rootCmd.Flag("profile").Value.String()
+	clients, err := ecs.NewAWSClients(profile)
 	if err != nil {
 		log.Fatalf("Failed to initialize AWS clients: %v\n", err)
 	}

--- a/cmd/revisions.go
+++ b/cmd/revisions.go
@@ -38,7 +38,8 @@ func revisionsHandler(cmd *cobra.Command, args []string) {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
 
-	clients, err := ecs.NewAWSClients()
+	profile := rootCmd.Flag("profile").Value.String()
+	clients, err := ecs.NewAWSClients(profile)
 	if err != nil {
 		log.Fatalf("Failed to initialize AWS clients: %v\n", err)
 	}

--- a/cmd/revisions.go
+++ b/cmd/revisions.go
@@ -39,7 +39,7 @@ func revisionsHandler(cmd *cobra.Command, args []string) {
 	defer cancel()
 
 	profile := rootCmd.Flag("profile").Value.String()
-	clients, err := ecs.NewAWSClients(profile)
+	clients, err := ecs.NewAWSClients(ctx, profile)
 	if err != nil {
 		log.Fatalf("Failed to initialize AWS clients: %v\n", err)
 	}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -52,7 +52,8 @@ func runHandler(dockerImageTag *string, execWait *bool) func(*cobra.Command, []s
 		ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 		defer cancel()
 
-		clients, err := ecs.NewAWSClients()
+		profile := rootCmd.Flag("profile").Value.String()
+		clients, err := ecs.NewAWSClients(profile)
 		if err != nil {
 			log.Fatalf("Failed to initialize AWS clients: %v\n", err)
 		}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -53,7 +53,7 @@ func runHandler(dockerImageTag *string, execWait *bool) func(*cobra.Command, []s
 		defer cancel()
 
 		profile := rootCmd.Flag("profile").Value.String()
-		clients, err := ecs.NewAWSClients(profile)
+		clients, err := ecs.NewAWSClients(ctx, profile)
 		if err != nil {
 			log.Fatalf("Failed to initialize AWS clients: %v\n", err)
 		}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -23,7 +23,7 @@ func newVersionCommand() *cobra.Command {
 }
 
 func versionHandler(cmd *cobra.Command, args []string) {
-	fmt.Printf("runecs %s\n", version.Version)
+	fmt.Printf("%s\n", version.Version)
 }
 
 func SetVersion(v *Version) {

--- a/docs/aws-authentication.md
+++ b/docs/aws-authentication.md
@@ -1,0 +1,21 @@
+# AWS Authentication Configuration
+
+RunECS supports multiple methods for AWS authentication:
+
+## Using Environment Variables
+
+AWS credential configuration through environment variables is also supported as documented in the [AWS CLI Environment Variables guide](https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-envvars.html). This approach integrates seamlessly with tools like [direnv](https://direnv.net/), enabling distinct AWS account configurations, regions, and other settings to be maintained on a per-directory or per-project basis.
+
+## Using AWS Credential Profiles
+
+AWS credential profiles can be specified using the global `--profile` parameter, allowing you to easily switch between different AWS accounts or roles. Profiles are configured in the AWS credentials file as documented in the [AWS CLI Configuration Files guide](https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-files.html).
+
+```bash
+# Use a specific AWS profile
+runecs list --profile production
+
+# Deploy using a different profile
+runecs deploy --service myapp/web -i latest --profile staging
+```
+
+The credentials file is typically located at `~/.aws/credentials`.

--- a/pkg/ecs/client.go
+++ b/pkg/ecs/client.go
@@ -25,13 +25,18 @@ import (
 )
 
 // NewAWSClients creates and initializes AWS service clients with shared configuration
-func NewAWSClients() (*AWSClients, error) {
+func NewAWSClients(profile string) (*AWSClients, error) {
 	configFunctions := []func(*config.LoadOptions) error{
 		config.WithRetryer(func() aws.Retryer {
 			return retry.NewStandard(func(o *retry.StandardOptions) {
 				o.MaxAttempts = defaultNumberOfRetries
 			})
 		}),
+	}
+
+	// Add profile configuration if specified
+	if profile != "" {
+		configFunctions = append(configFunctions, config.WithSharedConfigProfile(profile))
 	}
 
 	cfg, err := config.LoadDefaultConfig(context.Background(), configFunctions...)

--- a/pkg/ecs/client.go
+++ b/pkg/ecs/client.go
@@ -25,7 +25,7 @@ import (
 )
 
 // NewAWSClients creates and initializes AWS service clients with shared configuration
-func NewAWSClients(profile string) (*AWSClients, error) {
+func NewAWSClients(ctx context.Context, profile string) (*AWSClients, error) {
 	configFunctions := []func(*config.LoadOptions) error{
 		config.WithRetryer(func() aws.Retryer {
 			return retry.NewStandard(func(o *retry.StandardOptions) {
@@ -39,7 +39,7 @@ func NewAWSClients(profile string) (*AWSClients, error) {
 		configFunctions = append(configFunctions, config.WithSharedConfigProfile(profile))
 	}
 
-	cfg, err := config.LoadDefaultConfig(context.Background(), configFunctions...)
+	cfg, err := config.LoadDefaultConfig(ctx, configFunctions...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize AWS configuration: %w", err)
 	}


### PR DESCRIPTION
This pull request adds support for specifying an AWS credential profile via a new `--profile` flag, allowing users to easily switch between AWS accounts or roles when running commands. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a global --profile flag to select an AWS credential profile across commands (list, deploy, prune, restart, revisions, run). Commands use the profile when provided; default behavior unchanged when omitted.

* **Documentation**
  * Added "AWS Authentication" docs covering Environment Variables and AWS Credential Profiles.
  * Included examples showing --profile usage and noted typical credentials file location (~/.aws/credentials).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->