### PR TITLE
docs: add Docker installation and usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,18 @@ go install github.com/meap/runecs@latest
 
 Pre-compiled binaries for all platforms are available on our [releases page](https://github.com/meap/runecs/releases).
 
+### Docker
+
+RunECS is also available as a Docker image for containerized execution:
+
+```bash
+docker run \
+  -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
+  -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY \
+  -e AWS_REGION=$AWS_REGION \
+  preichl/runecs list
+```
+
 ## Configuration
 
 ### AWS Credentials


### PR DESCRIPTION
## Summary
- Added Docker section to README.md with instructions for running runecs via Docker container
- Included example command with AWS credential environment variables

## Test plan
- [ ] Verify Docker command syntax is correct
- [ ] Confirm Docker image `preichl/runecs` is available on Docker Hub
- [ ] Test that the Docker run command works with valid AWS credentials