### PR TITLE
Add Docker Pulls badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 [![GitHub release (**latest** by date)](https://img.shields.io/github/v/release/meap/runecs?logo=GitHub)](https://github.com/meap/runecs/releases)
 [![GitHub all releases](https://img.shields.io/github/downloads/meap/runecs/total?label=all%20time%20downloads)](https://github.com/meap/runecs/releases/)
+[![Docker Pulls](https://img.shields.io/docker/pulls/preichl/runecs?logo=docker)](https://hub.docker.com/r/preichl/runecs)
 
 </div>
 


### PR DESCRIPTION
## Summary

- Added Docker Pulls badge to display the total number of pulls for the `preichl/runecs` Docker image
- Badge is placed alongside existing GitHub release and download badges

## Changes

- Added shields.io Docker Pulls badge with Docker logo
- Links to Docker Hub repository page at https://hub.docker.com/r/preichl/runecs
- Maintains centered alignment with existing badges

## Test Plan

- [x] Verified badge URL follows shields.io documentation format
- [x] Confirmed Docker repository exists at `preichl/runecs`
- [x] Badge placement maintains visual consistency with existing badges