### PR TITLE
Add ECS service scaling command

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,16 @@ runecs run "echo \"HELLO WORLD\"" -w --service mycanvas-ecs-staging-cluster/web
 
 Both AWS Fargate and EC2 capacity providers are supported, with the appropriate launch type being automatically selected based on service configuration. When the `-w` flag is used, task completion is awaited and full output is streamed to the terminal, making it ideal for interactive debugging and migration scripts.
 
+### Scale ECS Services
+
+The desired count of tasks for an ECS service can be adjusted instantly:
+
+```bash
+runecs scale 5 --service mycanvas-ecs-staging-cluster/web
+```
+
+This command directly modifies the service's desired count using `UpdateService`, providing immediate scaling without creating task sets or managing deployment configurations.
+
 ### Restart ECS Services
 
 ECS services can be gracefully restarted without downtime, or immediate task termination can be forced when required:

--- a/internal/ecs/scale.go
+++ b/internal/ecs/scale.go
@@ -1,0 +1,80 @@
+// Copyright (c) Petr Reichl and affiliates. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ecs
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/service/ecs"
+)
+
+const (
+	minDesiredCount = 1
+	maxDesiredCount = 1000
+)
+
+var ErrInvalidDesiredCount = errors.New("desired count must be greater than 0")
+
+func Scale(ctx context.Context, clients *AWSClients, cluster, service string, desiredCount int32) (*ScaleResult, error) {
+	if desiredCount < minDesiredCount {
+		return nil, fmt.Errorf("%w: got %d, minimum is %d", ErrInvalidDesiredCount, desiredCount, minDesiredCount)
+	}
+
+	if desiredCount > maxDesiredCount {
+		return nil, fmt.Errorf("desired count exceeds maximum: got %d, maximum is %d", desiredCount, maxDesiredCount)
+	}
+
+	describeResp, err := clients.ECS.DescribeServices(ctx, &ecs.DescribeServicesInput{
+		Cluster:  &cluster,
+		Services: []string{service},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to describe service: %w", err)
+	}
+
+	if len(describeResp.Services) == 0 {
+		return nil, fmt.Errorf("service %s not found in cluster %s", service, cluster)
+	}
+
+	svc := describeResp.Services[0]
+	if svc.Status == nil || *svc.Status != "ACTIVE" {
+		return nil, fmt.Errorf("service %s is not in ACTIVE state", service)
+	}
+
+	previousDesiredCount := svc.DesiredCount
+
+	updateResp, err := clients.ECS.UpdateService(ctx, &ecs.UpdateServiceInput{
+		Cluster:      &cluster,
+		Service:      &service,
+		DesiredCount: &desiredCount,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to update service: %w", err)
+	}
+
+	result := &ScaleResult{
+		PreviousDesiredCount: previousDesiredCount,
+		NewDesiredCount:      desiredCount,
+		ClusterName:          cluster,
+		ServiceName:          service,
+	}
+
+	if updateResp.Service != nil && updateResp.Service.ServiceArn != nil {
+		result.ServiceArn = *updateResp.Service.ServiceArn
+	}
+
+	return result, nil
+}

--- a/internal/ecs/types.go
+++ b/internal/ecs/types.go
@@ -131,3 +131,12 @@ type ClusterInfo struct {
 	Name     string
 	Services []ServiceInfo
 }
+
+// ScaleResult contains the result of a service scaling operation
+type ScaleResult struct {
+	ServiceArn           string
+	PreviousDesiredCount int32
+	NewDesiredCount      int32
+	ClusterName          string
+	ServiceName          string
+}


### PR DESCRIPTION
## Summary
- Implemented new `scale` command to adjust ECS service task counts
- Added validation to prevent scaling to 0 tasks (minimum is 1, maximum is 1000)
- Uses AWS ECS UpdateService API for direct scaling without task sets

## Implementation Details
- Created `internal/ecs/scale.go` with Scale function that:
  - Validates desired count is between 1-1000
  - Retrieves current service state via DescribeServices
  - Updates service desired count via UpdateService
  - Returns detailed result with previous and new counts
- Added `ScaleResult` type to track operation details
- Updated `cmd/scale.go` to use the new Scale function
- Used lipgloss for consistent bold formatting of cluster/service names

## Test Plan
- [ ] Test scaling up a service (e.g., from 2 to 5 tasks)
- [ ] Test scaling down a service (e.g., from 5 to 1 task)
- [ ] Verify validation prevents scaling to 0
- [ ] Verify validation prevents scaling above 1000
- [ ] Test with invalid service names to ensure proper error handling
- [ ] Verify output displays previous and new task counts correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a scale command to instantly adjust an ECS service’s task count: runecs scale <count> --service <cluster/service>. Validates count (1–1000), supports cancellation (Ctrl+C), and confirms the previous and new desired counts on success.

- Documentation
  - Added a “Scale ECS Services” section explaining the new command, usage, and behavior (immediate scaling via UpdateService).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->