### PR TITLE
Add comprehensive logs functionality with real-time streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,22 @@ runecs scale 5 --service mycanvas-ecs-staging-cluster/web
 
 This command directly modifies the service's desired count using `UpdateService`, providing immediate scaling without creating task sets or managing deployment configurations.
 
+### View ECS Service Logs
+
+Access CloudWatch logs for your ECS services with built-in streaming capabilities:
+
+```bash
+runecs logs --service mycanvas-ecs-staging-cluster/web
+```
+
+For real-time log monitoring, use the follow flag to stream logs as they are generated:
+
+```bash
+runecs logs -f --service mycanvas-ecs-staging-cluster/web
+```
+
+RunECS automatically discovers CloudWatch log groups and streams associated with your service. The tool fetches logs from all running tasks and displays them chronologically. Without the follow flag, it shows logs from the last hour. With follow mode, it provides real-time streaming until interrupted.
+
 ### Restart ECS Services
 
 Restart ECS services gracefully without downtime, or force immediate task termination when required:

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func newLogsCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                   "logs",
+		Short:                 "Show logs for the service",
+		DisableFlagsInUseLine: true,
+		RunE:                  logsHandler,
+	}
+
+	return cmd
+}
+
+func logsHandler(cmd *cobra.Command, args []string) error {
+	cluster, service, err := parseServiceFlag()
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("hello world - would show logs for %s/%s\n", cluster, service)
+	return nil
+}
+
+func init() {
+	rootCmd.AddCommand(newLogsCommand())
+}

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -56,15 +56,15 @@ func logsHandler(cmd *cobra.Command, args []string) error {
 }
 
 func showLogs(ctx context.Context, clients *ecs.AWSClients, cluster, service string) error {
-	fmt.Printf("Fetching logs from the last 5 minutes for service %s...\n", boldStyle.Render(cluster+"/"+service))
-	fiveMinutesAgo := time.Now().Add(-5*time.Minute).Unix() * 1000
-	logs, err := ecs.GetServiceLogs(ctx, clients, cluster, service, &fiveMinutesAgo)
+	fmt.Printf("Fetching logs from the last hour for service %s...\n", boldStyle.Render(cluster+"/"+service))
+	oneHourAgo := time.Now().Add(-time.Hour).Unix() * 1000
+	logs, err := ecs.GetServiceLogs(ctx, clients, cluster, service, &oneHourAgo)
 	if err != nil {
 		return fmt.Errorf("failed to get logs for service %s/%s: %w", cluster, service, err)
 	}
 
 	if len(logs) == 0 {
-		fmt.Println("No logs found in the last 5 minutes")
+		fmt.Println("No logs found in the last hour")
 		return nil
 	}
 

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -1,10 +1,20 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
+	"os"
+	"os/signal"
+	"sort"
+	"syscall"
+	"time"
 
+	"github.com/charmbracelet/lipgloss"
 	"github.com/spf13/cobra"
+	"runecs.io/v1/internal/ecs"
 )
+
+var boldStyle = lipgloss.NewStyle().Bold(true)
 
 func newLogsCommand() *cobra.Command {
 	cmd := &cobra.Command{
@@ -14,6 +24,7 @@ func newLogsCommand() *cobra.Command {
 		RunE:                  logsHandler,
 	}
 
+	cmd.PersistentFlags().BoolP("follow", "f", false, "follow log output")
 	return cmd
 }
 
@@ -23,8 +34,77 @@ func logsHandler(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	fmt.Printf("hello world - would show logs for %s/%s\n", cluster, service)
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+
+	profile := rootCmd.Flag("profile").Value.String()
+	clients, err := ecs.NewAWSClients(ctx, profile)
+	if err != nil {
+		return fmt.Errorf("failed to initialize AWS clients: %w", err)
+	}
+
+	follow, err := cmd.Flags().GetBool("follow")
+	if err != nil {
+		return fmt.Errorf("failed to get follow flag: %w", err)
+	}
+
+	if follow {
+		return followLogs(ctx, clients, cluster, service)
+	}
+
+	return showLogs(ctx, clients, cluster, service)
+}
+
+func showLogs(ctx context.Context, clients *ecs.AWSClients, cluster, service string) error {
+	fmt.Printf("Fetching logs from the last 5 minutes for service %s...\n", boldStyle.Render(cluster+"/"+service))
+	fiveMinutesAgo := time.Now().Add(-5*time.Minute).Unix() * 1000
+	logs, err := ecs.GetServiceLogs(ctx, clients, cluster, service, &fiveMinutesAgo)
+	if err != nil {
+		return fmt.Errorf("failed to get logs for service %s/%s: %w", cluster, service, err)
+	}
+
+	if len(logs) == 0 {
+		fmt.Println("No logs found in the last 5 minutes")
+		return nil
+	}
+
+	sort.Slice(logs, func(i, j int) bool {
+		return logs[i].Timestamp < logs[j].Timestamp
+	})
+
+	for _, log := range logs {
+		timestamp := time.Unix(log.Timestamp/1000, (log.Timestamp%1000)*1000000)
+		fmt.Printf("%s %s\n", timestamp.Format("2006-01-02 15:04:05"), log.Message)
+	}
+
+	fmt.Printf("\nDisplayed %d log entries\n", len(logs))
 	return nil
+}
+
+func followLogs(ctx context.Context, clients *ecs.AWSClients, cluster, service string) error {
+	fmt.Printf("Starting live tail for service %s...\n", boldStyle.Render(cluster+"/"+service))
+	logChan, closeFunc, err := ecs.TailServiceLogs(ctx, clients, cluster, service)
+	if err != nil {
+		return fmt.Errorf("failed to start tailing logs: %w", err)
+	}
+	defer closeFunc()
+
+	fmt.Println("Connected. Streaming logs (press Ctrl+C to stop)...")
+
+	for {
+		select {
+		case <-ctx.Done():
+			fmt.Println("\nLog stream closed")
+			return nil
+		case log, ok := <-logChan:
+			if !ok {
+				fmt.Println("\nLog stream closed")
+				return nil
+			}
+			timestamp := time.Unix(log.Timestamp/1000, (log.Timestamp%1000)*1000000)
+			fmt.Printf("%s %s\n", timestamp.Format("2006-01-02 15:04:05"), log.Message)
+		}
+	}
 }
 
 func init() {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -76,9 +76,6 @@ func runHandler(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Display service loading information
-	fmt.Printf("Service '%s' loaded.\n", service)
-
 	// Display task definition information
 	if result.NewTaskDefCreated {
 		fmt.Printf("New task definition %s created\n", result.TaskDefinition)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -16,19 +16,16 @@ import (
 )
 
 func newRunCommand() *cobra.Command {
-	var dockerImageTag string
-	var execWait bool
-
 	cmd := &cobra.Command{
 		Use:                   "run [cmd]",
 		Short:                 "Execute a one-off process in an AWS ECS cluster",
 		Args:                  cobra.MinimumNArgs(1),
 		DisableFlagsInUseLine: true,
-		RunE:                  runHandler(&dockerImageTag, &execWait),
+		RunE:                  runHandler,
 	}
 
-	cmd.PersistentFlags().BoolVarP(&execWait, "wait", "w", false, "wait for task to finish")
-	cmd.PersistentFlags().StringVarP(&dockerImageTag, "image-tag", "i", "", "docker image tag")
+	cmd.PersistentFlags().BoolP("wait", "w", false, "wait for task to finish")
+	cmd.PersistentFlags().StringP("image-tag", "i", "", "docker image tag")
 	return cmd
 }
 
@@ -43,60 +40,68 @@ func parseCommandArgs(args []string) ([]string, error) {
 	return args, nil
 }
 
-func runHandler(dockerImageTag *string, execWait *bool) func(*cobra.Command, []string) error {
-	return func(cmd *cobra.Command, args []string) error {
-		cluster, service, err := parseServiceFlag()
-		if err != nil {
-			return err
-		}
-
-		// Set up context that cancels on interrupt signal for proper Ctrl+C handling
-		ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-		defer cancel()
-
-		profile := rootCmd.Flag("profile").Value.String()
-		clients, err := ecs.NewAWSClients(ctx, profile)
-		if err != nil {
-			return fmt.Errorf("failed to initialize AWS clients: %w", err)
-		}
-
-		parsedArgs, err := parseCommandArgs(args)
-		if err != nil {
-			return fmt.Errorf("error parsing command arguments: %w", err)
-		}
-
-		result, err := ecs.Execute(ctx, clients, cluster, service, parsedArgs, *execWait, *dockerImageTag)
-		if err != nil {
-			return err
-		}
-
-		// Display service loading information
-		fmt.Printf("Service '%s' loaded.\n", result.ServiceName)
-
-		// Display task definition information
-		if result.NewTaskDefCreated {
-			fmt.Printf("New task definition %s created\n", result.TaskDefinition)
-		} else {
-			fmt.Printf("Using task definition %s\n", result.TaskDefinition)
-		}
-
-		fmt.Println()
-
-		// Display task execution information
-		fmt.Printf("Task %s executed\n", result.TaskArn)
-
-		// Display logs if waiting
-		if *execWait {
-			for _, logEntry := range result.Logs {
-				fmt.Println(logEntry.StreamName, logEntry.Message)
-			}
-
-			if result.Finished {
-				fmt.Printf("Task %s finished\n", result.TaskArn)
-			}
-		}
-		return nil
+func runHandler(cmd *cobra.Command, args []string) error {
+	cluster, service, err := parseServiceFlag()
+	if err != nil {
+		return err
 	}
+
+	// Set up context that cancels on interrupt signal for proper Ctrl+C handling
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+
+	profile := rootCmd.Flag("profile").Value.String()
+	clients, err := ecs.NewAWSClients(ctx, profile)
+	if err != nil {
+		return fmt.Errorf("failed to initialize AWS clients: %w", err)
+	}
+
+	execWait, err := cmd.Flags().GetBool("wait")
+	if err != nil {
+		return fmt.Errorf("failed to get wait flag: %w", err)
+	}
+
+	dockerImageTag, err := cmd.Flags().GetString("image-tag")
+	if err != nil {
+		return fmt.Errorf("failed to get image-tag flag: %w", err)
+	}
+
+	parsedArgs, err := parseCommandArgs(args)
+	if err != nil {
+		return fmt.Errorf("error parsing command arguments: %w", err)
+	}
+
+	result, err := ecs.Execute(ctx, clients, cluster, service, parsedArgs, execWait, dockerImageTag)
+	if err != nil {
+		return err
+	}
+
+	// Display service loading information
+	fmt.Printf("Service '%s' loaded.\n", result.ServiceName)
+
+	// Display task definition information
+	if result.NewTaskDefCreated {
+		fmt.Printf("New task definition %s created\n", result.TaskDefinition)
+	} else {
+		fmt.Printf("Using task definition %s\n", result.TaskDefinition)
+	}
+
+	fmt.Println()
+
+	// Display task execution information
+	fmt.Printf("Task %s executed\n", result.TaskArn)
+
+	// Display logs if waiting
+	if execWait {
+		for _, logEntry := range result.Logs {
+			fmt.Println(logEntry.StreamName, logEntry.Message)
+		}
+
+		if result.Finished {
+			fmt.Printf("Task %s finished\n", result.TaskArn)
+		}
+	}
+	return nil
 }
 
 func init() {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -77,7 +77,7 @@ func runHandler(cmd *cobra.Command, args []string) error {
 	}
 
 	// Display service loading information
-	fmt.Printf("Service '%s' loaded.\n", result.ServiceName)
+	fmt.Printf("Service '%s' loaded.\n", service)
 
 	// Display task definition information
 	if result.NewTaskDefCreated {

--- a/internal/ecs/arn.go
+++ b/internal/ecs/arn.go
@@ -1,0 +1,62 @@
+// Copyright (c) Petr Reichl and affiliates. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ecs
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
+)
+
+// extractARNResource extracts the resource identifier from an AWS ARN
+// using the official AWS SDK ARN parser
+func extractARNResource(arnString string) (string, error) {
+	parsedARN, err := arn.Parse(arnString)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse ARN %q: %w", arnString, err)
+	}
+
+	// Extract the resource ID from the Resource field
+	// For resources like "task/abc123" or "user/David", get the part after "/"
+	if idx := strings.LastIndex(parsedARN.Resource, "/"); idx != -1 {
+		return parsedARN.Resource[idx+1:], nil
+	}
+
+	// If no "/" in resource, return the whole resource
+	return parsedARN.Resource, nil
+}
+
+// extractPartitionFromARN extracts the partition from an AWS ARN
+// Returns the partition (e.g., "aws", "aws-cn", "aws-us-gov")
+func extractPartitionFromARN(arnString string) (string, error) {
+	parsedARN, err := arn.Parse(arnString)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse ARN %q: %w", arnString, err)
+	}
+	return parsedARN.Partition, nil
+}
+
+// buildARN constructs an AWS ARN using the provided components
+// and returns the canonical string representation
+func buildARN(partition, service, region, accountID, resource string) string {
+	arnStruct := arn.ARN{
+		Partition: partition,
+		Service:   service,
+		Region:    region,
+		AccountID: accountID,
+		Resource:  resource,
+	}
+	return arnStruct.String()
+}

--- a/internal/ecs/client.go
+++ b/internal/ecs/client.go
@@ -22,6 +22,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
 )
 
 // NewAWSClients creates and initializes AWS service clients with shared configuration
@@ -47,6 +48,7 @@ func NewAWSClients(ctx context.Context, profile string) (*AWSClients, error) {
 	return &AWSClients{
 		ECS:            ecs.NewFromConfig(cfg),
 		CloudWatchLogs: cloudwatchlogs.NewFromConfig(cfg),
+		STS:            sts.NewFromConfig(cfg),
 		Region:         cfg.Region,
 	}, nil
 }

--- a/internal/ecs/execute.go
+++ b/internal/ecs/execute.go
@@ -113,8 +113,14 @@ func waitForTaskCompletion(ctx context.Context, clients *AWSClients, cluster str
 		return fmt.Errorf("failed to get caller identity: %w", err)
 	}
 
-	// Construct the LogGroup ARN
-	logGroupArn := fmt.Sprintf("arn:aws:logs:%s:%s:log-group:%s", clients.Region, *identity.Account, tdef.LogGroup)
+	// Extract partition from caller's ARN to handle different AWS partitions
+	partition, err := extractPartitionFromARN(*identity.Arn)
+	if err != nil {
+		return fmt.Errorf("failed to extract partition from caller ARN: %w", err)
+	}
+
+	// Construct the LogGroup ARN with correct partition
+	logGroupArn := buildARN(partition, "logs", clients.Region, *identity.Account, fmt.Sprintf("log-group:%s", tdef.LogGroup))
 
 	// Extract task ID from task ARN for log stream pattern
 	taskID, err := extractARNResource(taskArn)

--- a/internal/ecs/execute.go
+++ b/internal/ecs/execute.go
@@ -243,7 +243,6 @@ func Execute(ctx context.Context, clients *AWSClients, cluster, service string, 
 	}
 
 	result := &ExecuteResult{
-		ServiceName:       service,
 		TaskDefinition:    taskDef,
 		TaskArn:           *executedTask.TaskArn,
 		NewTaskDefCreated: newTaskDefCreated,

--- a/internal/ecs/logs.go
+++ b/internal/ecs/logs.go
@@ -206,8 +206,14 @@ func TailServiceLogs(ctx context.Context, clients *AWSClients, cluster, service 
 		return nil, nil, fmt.Errorf("failed to get caller identity: %w", err)
 	}
 
-	// Construct the LogGroup ARN
-	logGroupArn := fmt.Sprintf("arn:aws:logs:%s:%s:log-group:%s", clients.Region, *identity.Account, logGroup)
+	// Extract partition from caller's ARN to handle different AWS partitions
+	partition, err := extractPartitionFromARN(*identity.Arn)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to extract partition from caller ARN: %w", err)
+	}
+
+	// Construct the LogGroup ARN with correct partition
+	logGroupArn := buildARN(partition, "logs", clients.Region, *identity.Account, fmt.Sprintf("log-group:%s", logGroup))
 
 	// Use LogStreamNamePrefixes to capture all streams for this service's containers
 	logStreamPrefixPattern := fmt.Sprintf("%s/%s/", logStreamPrefix, containerName)

--- a/internal/ecs/types.go
+++ b/internal/ecs/types.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
 )
 
 const (
@@ -28,6 +29,7 @@ const (
 type AWSClients struct {
 	ECS            *ecs.Client
 	CloudWatchLogs *cloudwatchlogs.Client
+	STS            *sts.Client
 	Region         string
 }
 
@@ -48,9 +50,15 @@ type LogEntry struct {
 	Timestamp  int64
 }
 
+// LogStreamPrefix represents log configuration for a container
+type LogStreamPrefix struct {
+	LogGroup      string
+	StreamPrefix  string
+	ContainerName string
+}
+
 // ExecuteResult contains the result of task execution
 type ExecuteResult struct {
-	ServiceName       string
 	TaskDefinition    string
 	TaskArn           string
 	NewTaskDefCreated bool

--- a/internal/ecs/utils.go
+++ b/internal/ecs/utils.go
@@ -2,29 +2,8 @@ package ecs
 
 import (
 	"fmt"
-	"strings"
 	"time"
-
-	"github.com/aws/aws-sdk-go-v2/aws/arn"
 )
-
-// extractARNResource extracts the resource identifier from an AWS ARN
-// using the official AWS SDK ARN parser
-func extractARNResource(arnString string) (string, error) {
-	parsedARN, err := arn.Parse(arnString)
-	if err != nil {
-		return "", fmt.Errorf("failed to parse ARN %q: %w", arnString, err)
-	}
-
-	// Extract the resource ID from the Resource field
-	// For resources like "task/abc123" or "user/David", get the part after "/"
-	if idx := strings.LastIndex(parsedARN.Resource, "/"); idx != -1 {
-		return parsedARN.Resource[idx+1:], nil
-	}
-
-	// If no "/" in resource, return the whole resource
-	return parsedARN.Resource, nil
-}
 
 // formatRunningTime formats a duration into a human-readable string.
 // For durations >= 24 hours, it shows days, hours, and minutes (e.g., "2d 5h 30m").


### PR DESCRIPTION
## Summary
- Add new `logs` command for viewing ECS service logs from CloudWatch
- Implement real-time log streaming with `-f/--follow` flag
- Support for AWS partitions (aws, aws-cn, aws-us-gov) in log group ARN construction
- Automatic discovery of CloudWatch log groups and streams for ECS services

## Key Features
- **Basic log viewing**: `runecs logs --service cluster/service` shows logs from the last hour
- **Real-time streaming**: `runecs logs -f --service cluster/service` provides live log tailing
- **Multi-task support**: Aggregates logs from all running tasks in a service
- **Chronological ordering**: Displays logs sorted by timestamp across all tasks
- **AWS partition support**: Works across different AWS partitions (standard, China, GovCloud)

## Implementation Details
- New `cmd/logs.go` command with follow flag support
- Enhanced `internal/ecs/logs.go` with comprehensive logging functionality:
  - `GetServiceLogs()` for fetching historical logs
  - `TailServiceLogs()` for real-time streaming
  - `TailLogGroups()` for generic CloudWatch log group tailing
- Improved ARN handling with partition support in `internal/ecs/arn.go`
- Signal handling for graceful shutdown on Ctrl+C
- Robust error handling for missing log configurations

## Test Plan
- [x] Test basic log viewing for services with CloudWatch logging
- [x] Test real-time log streaming with follow mode
- [x] Test graceful shutdown with Ctrl+C
- [x] Test with services having multiple running tasks
- [x] Test error handling for services without CloudWatch logging
- [x] Test AWS partition support across different regions