### PR TITLE
Add AWS_REGION example for profiles without region

### DIFF
--- a/docs/aws-authentication.md
+++ b/docs/aws-authentication.md
@@ -76,4 +76,7 @@ runecs list --profile production
 
 # Deploy using a different profile
 runecs deploy --service myapp/web -i latest --profile staging
+
+# If profile doesn't have region defined, specify it with AWS_REGION
+AWS_REGION=eu-central-1 runecs list --profile staging
 ```


### PR DESCRIPTION
## Summary
- Added example showing how to specify AWS region when using profiles that don't have a region defined
- Demonstrates usage of AWS_REGION environment variable with --profile flag

## Test plan
- [x] Verify example syntax is correct
- [x] Confirm documentation follows existing style
- [x] Check that example provides clear guidance for users