### PR TITLE
Add error context; add lint target

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,6 +15,7 @@ linters:
     - varnamelen
     - gosmopolitan
     - mnd
+    - gochecknoinits
 
   exclusions:
     warn-unused: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,6 +16,8 @@ linters:
     - gosmopolitan
     - mnd
     - gochecknoinits
+    - depguard
+    - revive
 
   exclusions:
     warn-unused: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,25 +1,8 @@
+version: "2"
 linters:
-  enable-all: true
+  default: all
   disable:
-    - funlen
-    - gochecknoinits
-    - wsl
-    - exhaustruct
-    - execinquery
-    - exportloopref
-    - gomnd
-    - copyloopvar
-    - intrange
-    - gochecknoglobals
-    - wrapcheck
-    - err113
-    - depguard
-    - mnd
-    - lll
-    - cyclop
-    - revive
-    - godox
-    - gofumpt
-    - gosec
-    - contextcheck
-    - forbidigo
+    - wsl_v5
+
+  exclusions:
+    warn-unused: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,6 +3,7 @@ linters:
   default: all
   disable:
     - wsl_v5
+    - ireturn
 
   exclusions:
     warn-unused: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,6 +11,10 @@ linters:
     - err113
     - godot
     - godox
+    - prealloc
+    - varnamelen
+    - gosmopolitan
+    - mnd
 
   exclusions:
     warn-unused: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,8 +2,15 @@ version: "2"
 linters:
   default: all
   disable:
+    - wsl
     - wsl_v5
     - ireturn
+    - lll
+    - exhaustruct
+    - gochecknoglobals
+    - err113
+    - godot
+    - godox
 
   exclusions:
     warn-unused: true

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,5 @@
 build:
 	go build -o bin/runecs main.go
+
+lint:
+	golangci-lint run

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -35,6 +35,7 @@ func completionHandler(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to generate completion script: %w", err)
 	}
+
 	return nil
 }
 

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -68,8 +68,8 @@ func deployHandler(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("deploy failed: %w", err)
 	}
 
-	fmt.Printf("New task revision %s has been created\n", result.TaskDefinitionArn)
-	fmt.Printf("Service %s has been updated.\n", result.ServiceArn)
+	cmd.Printf("New task revision %s has been created\n", result.TaskDefinitionArn)
+	cmd.Printf("Service %s has been updated.\n", result.ServiceArn)
 
 	return nil
 }

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -22,6 +22,7 @@ func newDeployCommand() *cobra.Command {
 	}
 
 	cmd.PersistentFlags().StringP("image-tag", "i", "", "docker image tag")
+
 	return cmd
 }
 
@@ -30,6 +31,7 @@ func deployPreRunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to get image-tag flag: %w", err)
 	}
+
 	if dockerImageTag == "" {
 		return errors.New("--image-tag flag is required")
 	}
@@ -42,7 +44,9 @@ func deployHandler(cmd *cobra.Command, args []string) error {
 	defer cancel()
 
 	profile := rootCmd.Flag("profile").Value.String()
+
 	clients, err := ecs.NewAWSClients(ctx, profile)
+
 	if err != nil {
 		return fmt.Errorf("failed to initialize AWS clients: %w", err)
 	}
@@ -56,13 +60,16 @@ func deployHandler(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+
 	result, err := ecs.Deploy(ctx, clients, cluster, service, dockerImageTag)
+
 	if err != nil {
 		return fmt.Errorf("deploy failed: %w", err)
 	}
 
 	fmt.Printf("New task revision %s has been created\n", result.TaskDefinitionArn)
 	fmt.Printf("Service %s has been updated.\n", result.ServiceArn)
+
 	return nil
 }
 

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -35,6 +35,7 @@ func deployPreRunE(cmd *cobra.Command, args []string) error {
 	if dockerImageTag == "" {
 		return errors.New("--image-tag flag is required")
 	}
+
 	return nil
 }
 

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -35,6 +35,7 @@ func listHandler(cmd *cobra.Command, args []string) error {
 
 	profile := rootCmd.Flag("profile").Value.String()
 	clients, err := ecs.NewAWSClients(ctx, profile)
+
 	if err != nil {
 		return fmt.Errorf("failed to initialize AWS clients: %w", err)
 	}
@@ -62,6 +63,7 @@ func displayServices(clusters []ecs.ClusterInfo, region string) {
 
 	for _, cluster := range clusters {
 		list := list.New().EnumeratorStyle(enumStyle)
+
 		fmt.Println(cluster.Name)
 
 		for _, service := range cluster.Services {
@@ -87,6 +89,7 @@ func displayServicesWithDetails(clusters []ecs.ClusterInfo, region string) {
 		for _, service := range cluster.Services {
 			boldServiceName := lipgloss.NewStyle().Bold(true).Render(service.Name)
 			serviceName := fmt.Sprintf("%s/%s", service.ClusterName, boldServiceName)
+
 			for _, task := range service.Tasks {
 				rows = append(rows, []string{
 					serviceName,

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -43,7 +43,7 @@ func listHandler(cmd *cobra.Command, args []string) error {
 
 	clusters, err := ecs.GetClusters(ctx, clients, all)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to get clusters: %w", err)
 	}
 
 	if all {

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -47,25 +47,25 @@ func listHandler(cmd *cobra.Command, args []string) error {
 	}
 
 	if all {
-		displayServicesWithDetails(clusters, clients.Region)
+		displayServicesWithDetails(cmd, clusters, clients.Region)
 	} else {
-		displayServices(clusters, clients.Region)
+		displayServices(cmd, clusters, clients.Region)
 	}
 
 	return nil
 }
 
-func displayServices(clusters []ecs.ClusterInfo, region string) {
+func displayServices(cmd *cobra.Command, clusters []ecs.ClusterInfo, region string) {
 	boldStyle := lipgloss.NewStyle().Bold(true)
 	enumStyle := lipgloss.NewStyle().MarginLeft(2).MarginRight(1)
 
-	fmt.Printf("Services in all clusters (region: %s):\n", boldStyle.Render(region))
-	fmt.Println()
+	cmd.Printf("Services in all clusters (region: %s):\n", boldStyle.Render(region))
+	cmd.Println()
 
 	for _, cluster := range clusters {
 		list := list.New().EnumeratorStyle(enumStyle)
 
-		fmt.Println(cluster.Name)
+		cmd.Println(cluster.Name)
 
 		for _, service := range cluster.Services {
 			serviceName := boldStyle.Render(service.Name)
@@ -73,13 +73,13 @@ func displayServices(clusters []ecs.ClusterInfo, region string) {
 		}
 
 		if len(cluster.Services) > 0 {
-			fmt.Println(list)
-			fmt.Println()
+			cmd.Println(list)
+			cmd.Println()
 		}
 	}
 }
 
-func displayServicesWithDetails(clusters []ecs.ClusterInfo, region string) {
+func displayServicesWithDetails(cmd *cobra.Command, clusters []ecs.ClusterInfo, region string) {
 	boldStyle := lipgloss.NewStyle().Bold(true)
 	headerStyle := lipgloss.NewStyle().Bold(true).Align(lipgloss.Center)
 	cellStyle := lipgloss.NewStyle().Padding(0, 1)
@@ -104,7 +104,7 @@ func displayServicesWithDetails(clusters []ecs.ClusterInfo, region string) {
 	}
 
 	if len(rows) == 0 {
-		fmt.Println("No running tasks found.")
+		cmd.Println("No running tasks found.")
 
 		return
 	}
@@ -125,9 +125,9 @@ func displayServicesWithDetails(clusters []ecs.ClusterInfo, region string) {
 		Headers("Service", "Task ID", "CPU", "Memory", "Running Time").
 		Rows(rows...)
 
-	fmt.Printf("Services with running tasks (region: %s):\n", boldStyle.Render(region))
-	fmt.Println()
-	fmt.Println(t)
+	cmd.Printf("Services with running tasks (region: %s):\n", boldStyle.Render(region))
+	cmd.Println()
+	cmd.Println(t)
 }
 
 func init() {

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -23,6 +23,7 @@ func newListCommand() *cobra.Command {
 	}
 
 	cmd.PersistentFlags().BoolP("all", "a", false, "include running tasks in output")
+
 	return cmd
 }
 
@@ -104,6 +105,7 @@ func displayServicesWithDetails(clusters []ecs.ClusterInfo, region string) {
 
 	if len(rows) == 0 {
 		fmt.Println("No running tasks found.")
+
 		return
 	}
 
@@ -117,6 +119,7 @@ func displayServicesWithDetails(clusters []ecs.ClusterInfo, region string) {
 			if col == 2 || col == 3 || col == 4 {
 				return cellStyle.Align(lipgloss.Right)
 			}
+
 			return cellStyle
 		}).
 		Headers("Service", "Task ID", "CPU", "Memory", "Running Time").

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -25,6 +25,7 @@ func newLogsCommand() *cobra.Command {
 	}
 
 	cmd.PersistentFlags().BoolP("follow", "f", false, "follow log output")
+
 	return cmd
 }
 
@@ -66,6 +67,7 @@ func showLogs(ctx context.Context, clients *ecs.AWSClients, cluster, service str
 
 	if len(logs) == 0 {
 		fmt.Println("No logs found in the last hour")
+
 		return nil
 	}
 
@@ -79,6 +81,7 @@ func showLogs(ctx context.Context, clients *ecs.AWSClients, cluster, service str
 	}
 
 	fmt.Printf("\nDisplayed %d log entries\n", len(logs))
+
 	return nil
 }
 
@@ -97,10 +100,12 @@ func followLogs(ctx context.Context, clients *ecs.AWSClients, cluster, service s
 		select {
 		case <-ctx.Done():
 			fmt.Println("\nLog stream closed")
+
 			return nil
 		case log, ok := <-logChan:
 			if !ok {
 				fmt.Println("\nLog stream closed")
+
 				return nil
 			}
 

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -57,6 +57,7 @@ func logsHandler(cmd *cobra.Command, args []string) error {
 
 func showLogs(ctx context.Context, clients *ecs.AWSClients, cluster, service string) error {
 	fmt.Printf("Fetching logs from the last hour for service %s...\n", boldStyle.Render(cluster+"/"+service))
+
 	oneHourAgo := time.Now().Add(-time.Hour).Unix() * 1000
 	logs, err := ecs.GetServiceLogs(ctx, clients, cluster, service, &oneHourAgo)
 	if err != nil {
@@ -87,6 +88,7 @@ func followLogs(ctx context.Context, clients *ecs.AWSClients, cluster, service s
 	if err != nil {
 		return fmt.Errorf("failed to start tailing logs: %w", err)
 	}
+
 	defer closeFunc()
 
 	fmt.Println("Connected. Streaming logs (press Ctrl+C to stop)...")
@@ -101,6 +103,7 @@ func followLogs(ctx context.Context, clients *ecs.AWSClients, cluster, service s
 				fmt.Println("\nLog stream closed")
 				return nil
 			}
+
 			timestamp := time.Unix(log.Timestamp/1000, (log.Timestamp%1000)*1000000)
 			fmt.Printf("%s %s\n", timestamp.Format("2006-01-02 15:04:05"), log.Message)
 		}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -49,9 +49,10 @@ func init() {
 	rootCmd.PersistentFlags().String("profile", "", "AWS profile to use for credentials")
 }
 
-func parseServiceFlag() (cluster, service string, err error) {
+func parseServiceFlag() (string, string, error) {
 	serviceValue := rootCmd.Flag("service").Value.String()
 
+	var cluster, service string
 	parsed := strings.Split(serviceValue, "/")
 	if len(parsed) == 2 {
 		cluster = parsed[0]

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -33,10 +33,7 @@ var rootCmd = &cobra.Command{
 		commandsWithoutService := []string{"completion", "help", "list", "version"}
 		serviceValue := cmd.Flag("service").Value.String()
 
-		serviceRequired := true
-		if slices.Contains(commandsWithoutService, cmd.Name()) {
-			serviceRequired = false
-		}
+		serviceRequired := !slices.Contains(commandsWithoutService, cmd.Name())
 
 		if serviceRequired && serviceValue == "" {
 			return errors.New("--service flag is required for this command")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -64,7 +64,7 @@ func parseServiceFlag() (cluster, service string, err error) {
 	}
 
 	if cluster == "" || service == "" {
-		return "", "", fmt.Errorf("missing cluster or service configuration")
+		return "", "", errors.New("missing cluster or service configuration")
 	}
 
 	return cluster, service, nil

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -69,7 +69,8 @@ func parseServiceFlag() (string, string, error) {
 }
 
 func Execute() {
-	if err := rootCmd.Execute(); err != nil {
+	err := rootCmd.Execute()
+	if err != nil {
 		os.Exit(1)
 	}
 }

--- a/cmd/prune.go
+++ b/cmd/prune.go
@@ -52,8 +52,8 @@ func pruneHandler(cmd *cobra.Command, args []string) error {
 	}
 
 	// Display families being processed
-	fmt.Printf("Processing %d task definition families: %v\n", len(result.Families), result.Families)
-	fmt.Println()
+	cmd.Printf("Processing %d task definition families: %v\n", len(result.Families), result.Families)
+	cmd.Println()
 
 	// Create lipgloss style for ARN formatting
 	arnStyle := lipgloss.NewStyle().Bold(true)
@@ -62,29 +62,29 @@ func pruneHandler(cmd *cobra.Command, args []string) error {
 	for _, task := range result.ProcessedTasks {
 		switch task.Action {
 		case "kept":
-			fmt.Printf("Task definition %s created %d days ago was skipped (%s)\n",
+			cmd.Printf("Task definition %s created %d days ago was skipped (%s)\n",
 				arnStyle.Render(task.Arn), task.DaysOld, task.Reason)
 		case "deleted":
 			if result.DryRun {
-				fmt.Printf("Task definition %s created %d days ago would be deregistered\n",
+				cmd.Printf("Task definition %s created %d days ago would be deregistered\n",
 					arnStyle.Render(task.Arn), task.DaysOld)
 			} else {
-				fmt.Printf("Task definition %s created %d days ago was deregistered\n",
+				cmd.Printf("Task definition %s created %d days ago was deregistered\n",
 					arnStyle.Render(task.Arn), task.DaysOld)
 			}
 		case "skipped":
-			fmt.Printf("Task definition %s skipped: %s\n", arnStyle.Render(task.Arn), task.Reason)
+			cmd.Printf("Task definition %s skipped: %s\n", arnStyle.Render(task.Arn), task.Reason)
 		}
 	}
 
-	fmt.Println()
+	cmd.Println()
 
 	// Display summary
 	if result.DryRun {
-		fmt.Printf("Total of %d task definitions. Will delete %d definitions.\n",
+		cmd.Printf("Total of %d task definitions. Will delete %d definitions.\n",
 			result.TotalCount, result.DeletedCount)
 	} else {
-		fmt.Printf("Total of %d task definitions. Deleted %d definitions.\n",
+		cmd.Printf("Total of %d task definitions. Deleted %d definitions.\n",
 			result.TotalCount, result.DeletedCount)
 	}
 

--- a/cmd/prune.go
+++ b/cmd/prune.go
@@ -48,7 +48,7 @@ func pruneHandler(cmd *cobra.Command, args []string) error {
 	}
 	result, err := ecs.Prune(ctx, clients, cluster, service, keepLastNr, keepDays, dryRun)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to prune service: %w", err)
 	}
 
 	// Display families being processed

--- a/cmd/prune.go
+++ b/cmd/prune.go
@@ -23,6 +23,7 @@ func newPruneCommand() *cobra.Command {
 	cmd.PersistentFlags().BoolP("dry-run", "", false, "dry run")
 	cmd.PersistentFlags().IntP("keep-last", "", defaultLastNumberOfTasks, "keep last N task definitions")
 	cmd.PersistentFlags().IntP("keep-days", "", defaultLastDays, "keep task definitions older than N days")
+
 	return cmd
 }
 
@@ -86,6 +87,7 @@ func pruneHandler(cmd *cobra.Command, args []string) error {
 		fmt.Printf("Total of %d task definitions. Deleted %d definitions.\n",
 			result.TotalCount, result.DeletedCount)
 	}
+
 	return nil
 }
 

--- a/cmd/restart.go
+++ b/cmd/restart.go
@@ -49,13 +49,13 @@ func restartHandler(cmd *cobra.Command, args []string) error {
 
 	if result.Method == "kill" {
 		for _, stoppedTask := range result.StoppedTasks {
-			fmt.Printf("Stopped task %s started %s\n", stoppedTask.TaskArn, humanize.Time(stoppedTask.StartedAt))
+			cmd.Printf("Stopped task %s started %s\n", stoppedTask.TaskArn, humanize.Time(stoppedTask.StartedAt))
 		}
 	} else {
-		fmt.Printf("Service %s restarted by starting new tasks using task definition %s.\n", service, result.TaskDefinition)
+		cmd.Printf("Service %s restarted by starting new tasks using task definition %s.\n", service, result.TaskDefinition)
 	}
 
-	fmt.Println("Done.")
+	cmd.Println("Done.")
 
 	return nil
 }

--- a/cmd/restart.go
+++ b/cmd/restart.go
@@ -21,6 +21,7 @@ func newRestartCommand() *cobra.Command {
 	}
 
 	cmd.PersistentFlags().BoolP("kill", "", false, "Stops running tasks, ECS starts a new one if the health check is properly set")
+
 	return cmd
 }
 
@@ -55,6 +56,7 @@ func restartHandler(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Println("Done.")
+
 	return nil
 }
 

--- a/cmd/revisions.go
+++ b/cmd/revisions.go
@@ -73,9 +73,9 @@ func revisionsHandler(cmd *cobra.Command, args []string) error {
 			repo := strings.Join(dockerParts[:len(dockerParts)-1], ":")
 			tag := dockerParts[len(dockerParts)-1]
 			styledTag := boldStyle.Render(tag)
-			fmt.Printf("%s: %s:%s\n", formattedDate, repo, styledTag)
+			cmd.Printf("%s: %s:%s\n", formattedDate, repo, styledTag)
 		} else {
-			fmt.Printf("%s: %s\n", formattedDate, revision.DockerURI)
+			cmd.Printf("%s: %s\n", formattedDate, revision.DockerURI)
 		}
 	}
 

--- a/cmd/revisions.go
+++ b/cmd/revisions.go
@@ -27,6 +27,7 @@ func newRevisionsCommand() *cobra.Command {
 	}
 
 	cmd.PersistentFlags().IntP("last", "", 0, "last N revisions")
+
 	return cmd
 }
 
@@ -77,6 +78,7 @@ func revisionsHandler(cmd *cobra.Command, args []string) error {
 			fmt.Printf("%s: %s\n", formattedDate, revision.DockerURI)
 		}
 	}
+
 	return nil
 }
 

--- a/cmd/revisions.go
+++ b/cmd/revisions.go
@@ -50,7 +50,7 @@ func revisionsHandler(cmd *cobra.Command, args []string) error {
 	}
 	result, err := ecs.Revisions(ctx, clients, cluster, service, revNr)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to get revisions: %w", err)
 	}
 
 	// Sort revisions by revision number in descending order

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -76,7 +76,7 @@ func runHandler(cmd *cobra.Command, args []string) error {
 
 	result, err := ecs.Execute(ctx, clients, cluster, service, parsedArgs, execWait, dockerImageTag)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to execute command: %w", err)
 	}
 
 	// Display task definition information

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -26,6 +26,7 @@ func newRunCommand() *cobra.Command {
 
 	cmd.PersistentFlags().BoolP("wait", "w", false, "wait for task to finish")
 	cmd.PersistentFlags().StringP("image-tag", "i", "", "docker image tag")
+
 	return cmd
 }
 
@@ -35,8 +36,10 @@ func parseCommandArgs(args []string) ([]string, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse command: %w", err)
 		}
+
 		return parsed, nil
 	}
+
 	return args, nil
 }
 
@@ -98,6 +101,7 @@ func runHandler(cmd *cobra.Command, args []string) error {
 			fmt.Printf("Task %s finished\n", result.TaskArn)
 		}
 	}
+
 	return nil
 }
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -81,24 +81,24 @@ func runHandler(cmd *cobra.Command, args []string) error {
 
 	// Display task definition information
 	if result.NewTaskDefCreated {
-		fmt.Printf("New task definition %s created\n", result.TaskDefinition)
+		cmd.Printf("New task definition %s created\n", result.TaskDefinition)
 	} else {
-		fmt.Printf("Using task definition %s\n", result.TaskDefinition)
+		cmd.Printf("Using task definition %s\n", result.TaskDefinition)
 	}
 
-	fmt.Println()
+	cmd.Println()
 
 	// Display task execution information
-	fmt.Printf("Task %s executed\n", result.TaskArn)
+	cmd.Printf("Task %s executed\n", result.TaskArn)
 
 	// Display logs if waiting
 	if execWait {
 		for _, logEntry := range result.Logs {
-			fmt.Println(logEntry.StreamName, logEntry.Message)
+			cmd.Println(logEntry.StreamName, logEntry.Message)
 		}
 
 		if result.Finished {
-			fmt.Printf("Task %s finished\n", result.TaskArn)
+			cmd.Printf("Task %s finished\n", result.TaskArn)
 		}
 	}
 

--- a/cmd/scale.go
+++ b/cmd/scale.go
@@ -51,6 +51,7 @@ func scalePreRunE(cmd *cobra.Command, args []string) error {
 	}
 
 	const minTaskCount = 1
+
 	const maxTaskCount = 1000
 
 	if value < minTaskCount || value > maxTaskCount {

--- a/cmd/scale.go
+++ b/cmd/scale.go
@@ -45,10 +45,11 @@ func scalePreRunE(cmd *cobra.Command, args []string) error {
 		return errors.New("scale command requires exactly one argument: the desired task count")
 	}
 
-	value, err := strconv.Atoi(args[0])
+	value64, err := strconv.ParseInt(args[0], 10, 32)
 	if err != nil {
 		return fmt.Errorf("invalid scale value: %w", err)
 	}
+	value := int(value64)
 
 	const minTaskCount = 1
 
@@ -62,10 +63,11 @@ func scalePreRunE(cmd *cobra.Command, args []string) error {
 }
 
 func scaleHandler(cmd *cobra.Command, args []string) error {
-	value, err := strconv.Atoi(args[0])
+	value64, err := strconv.ParseInt(args[0], 10, 32)
 	if err != nil {
 		return fmt.Errorf("invalid scale value: %w", err)
 	}
+	value := int32(value64)
 
 	cluster, service, err := parseServiceFlag()
 	if err != nil {
@@ -82,7 +84,7 @@ func scaleHandler(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to initialize AWS clients: %w", err)
 	}
 
-	result, err := ecs.Scale(ctx, clients, cluster, service, int32(value))
+	result, err := ecs.Scale(ctx, clients, cluster, service, value)
 	if err != nil {
 		return fmt.Errorf("failed to scale service: %w", err)
 	}

--- a/cmd/scale.go
+++ b/cmd/scale.go
@@ -92,7 +92,7 @@ func scaleHandler(cmd *cobra.Command, args []string) error {
 	// Create lipgloss style for service name formatting
 	boldStyle := lipgloss.NewStyle().Bold(true)
 
-	fmt.Printf("Service %s scaled from %d to %d tasks\n",
+	cmd.Printf("Service %s scaled from %d to %d tasks\n",
 		boldStyle.Render(fmt.Sprintf("%s/%s", result.ClusterName, result.ServiceName)),
 		result.PreviousDesiredCount, result.NewDesiredCount)
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 )
 
@@ -23,7 +21,7 @@ func newVersionCommand() *cobra.Command {
 }
 
 func versionHandler(cmd *cobra.Command, args []string) {
-	fmt.Printf("%s\n", version.Version)
+	cmd.Printf("%s\n", version.Version)
 }
 
 func SetVersion(v *Version) {

--- a/internal/ecs/arn.go
+++ b/internal/ecs/arn.go
@@ -45,6 +45,7 @@ func extractPartitionFromARN(arnString string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to parse ARN %q: %w", arnString, err)
 	}
+
 	return parsedARN.Partition, nil
 }
 
@@ -58,5 +59,6 @@ func buildARN(partition, service, region, accountID, resource string) string {
 		AccountID: accountID,
 		Resource:  resource,
 	}
+
 	return arnStruct.String()
 }

--- a/internal/ecs/deploy.go
+++ b/internal/ecs/deploy.go
@@ -37,7 +37,7 @@ func cloneTaskDef(ctx context.Context, cluster, service, dockerImageTag string, 
 	})
 
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to describe task definition: %w", err)
 	}
 
 	if len(response.TaskDefinition.ContainerDefinitions) > 1 {
@@ -52,7 +52,7 @@ func cloneTaskDef(ctx context.Context, cluster, service, dockerImageTag string, 
 	newDef := &ecs.RegisterTaskDefinitionInput{}
 	err = copier.Copy(newDef, response.TaskDefinition)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to copy task definition: %w", err)
 	}
 
 	if containerDef.Image == nil {
@@ -66,7 +66,7 @@ func cloneTaskDef(ctx context.Context, cluster, service, dockerImageTag string, 
 
 	output, err := svc.RegisterTaskDefinition(ctx, newDef)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to register task definition: %w", err)
 	}
 
 	if output.TaskDefinition == nil || output.TaskDefinition.TaskDefinitionArn == nil {

--- a/internal/ecs/deploy.go
+++ b/internal/ecs/deploy.go
@@ -50,7 +50,8 @@ func cloneTaskDef(ctx context.Context, cluster, service, dockerImageTag string, 
 	}
 
 	newDef := &ecs.RegisterTaskDefinitionInput{}
-	if err := copier.Copy(newDef, response.TaskDefinition); err != nil {
+	err = copier.Copy(newDef, response.TaskDefinition)
+	if err != nil {
 		return "", err
 	}
 

--- a/internal/ecs/execute.go
+++ b/internal/ecs/execute.go
@@ -120,7 +120,7 @@ func waitForTaskCompletion(ctx context.Context, clients *AWSClients, cluster str
 	}
 
 	// Construct the LogGroup ARN with correct partition
-	logGroupArn := buildARN(partition, "logs", clients.Region, *identity.Account, fmt.Sprintf("log-group:%s", tdef.LogGroup))
+	logGroupArn := buildARN(partition, "logs", clients.Region, *identity.Account, "log-group:"+tdef.LogGroup)
 
 	// Extract task ID from task ARN for log stream pattern
 	taskID, err := extractARNResource(taskArn)

--- a/internal/ecs/execute.go
+++ b/internal/ecs/execute.go
@@ -308,7 +308,8 @@ func Execute(ctx context.Context, clients *AWSClients, cluster, service string, 
 	}
 
 	if waitForCompletion {
-		if err := waitForTaskCompletion(ctx, clients, cluster, *executedTask.TaskArn, tdef, result); err != nil {
+		err = waitForTaskCompletion(ctx, clients, cluster, *executedTask.TaskArn, tdef, result)
+		if err != nil {
 			return result, err
 		}
 	}

--- a/internal/ecs/execute.go
+++ b/internal/ecs/execute.go
@@ -182,6 +182,7 @@ func waitForTaskCompletion(ctx context.Context, clients *AWSClients, cluster str
 			// Cancel the log collection context and wait for it to finish
 			cancel()
 			<-logsDone
+
 			break
 		}
 

--- a/internal/ecs/execute.go
+++ b/internal/ecs/execute.go
@@ -147,6 +147,7 @@ func waitForTaskCompletion(ctx context.Context, clients *AWSClients, cluster str
 
 	// Start goroutine to collect logs
 	logsDone := make(chan struct{})
+
 	go func() {
 		defer close(logsDone)
 		for {
@@ -219,8 +220,11 @@ func Execute(ctx context.Context, clients *AWSClients, cluster, service string, 
 
 	// Extract network configuration if available
 	taskDefArn := latestTaskDefArn
+
 	var subnets []string
+
 	var securityGroups []string
+
 	if serviceInfo.NetworkConfiguration != nil && serviceInfo.NetworkConfiguration.AwsvpcConfiguration != nil {
 		subnets = serviceInfo.NetworkConfiguration.AwsvpcConfiguration.Subnets
 		securityGroups = serviceInfo.NetworkConfiguration.AwsvpcConfiguration.SecurityGroups
@@ -238,6 +242,7 @@ func Execute(ctx context.Context, clients *AWSClients, cluster, service string, 
 	}
 
 	var taskDef string
+
 	newTaskDefCreated := false
 
 	if dockerImageTag != "" {
@@ -280,7 +285,6 @@ func Execute(ctx context.Context, clients *AWSClients, cluster, service string, 
 	}
 
 	output, err := clients.ECS.RunTask(ctx, runTaskInput)
-
 	if err != nil {
 		return nil, err
 	}

--- a/internal/ecs/list.go
+++ b/internal/ecs/list.go
@@ -88,9 +88,10 @@ func getTaskDetails(ctx context.Context, svc *ecs.Client, cluster string, servic
 	}
 
 	tasks := []TaskInfo{}
+
 	for _, task := range describeTasksOutput.Tasks {
-		// Výpočet délky běhu úlohy
 		var runningTime string
+
 		if task.StartedAt != nil {
 			duration := time.Since(*task.StartedAt)
 			runningTime = formatRunningTime(duration)
@@ -122,6 +123,7 @@ func GetClusters(ctx context.Context, clients *AWSClients, includeTasks bool) ([
 	}
 
 	clusters := []ClusterInfo{}
+
 	for _, clusterArn := range clusterArns {
 		serviceArns, err := getServiceArns(ctx, clients.ECS, clusterArn)
 		if err != nil {
@@ -129,6 +131,7 @@ func GetClusters(ctx context.Context, clients *AWSClients, includeTasks bool) ([
 		}
 
 		services := []ServiceInfo{}
+
 		for _, serviceArn := range serviceArns {
 			serviceName, err := extractARNResource(serviceArn)
 			if err != nil {

--- a/internal/ecs/logs.go
+++ b/internal/ecs/logs.go
@@ -182,12 +182,14 @@ func TailLogGroups(ctx context.Context, cwClient *cloudwatchlogs.Client, logGrou
 						slog.Error(ErrStreamError,
 							"error", err,
 							"context", "CloudWatch logs live tail stream")
+
 						return
 					}
 
 					if event == nil {
 						slog.Debug(ErrStreamNilEvent,
 							"context", "CloudWatch logs live tail stream")
+
 						return
 					}
 

--- a/internal/ecs/logs.go
+++ b/internal/ecs/logs.go
@@ -246,7 +246,7 @@ func TailServiceLogs(ctx context.Context, clients *AWSClients, cluster, service 
 	}
 
 	// Construct the LogGroup ARN with correct partition
-	logGroupArn := buildARN(partition, "logs", clients.Region, *identity.Account, fmt.Sprintf("log-group:%s", logGroup))
+	logGroupArn := buildARN(partition, "logs", clients.Region, *identity.Account, "log-group:"+logGroup)
 
 	// Use LogStreamNamePrefixes to capture all streams for this service's containers
 	logStreamPrefixPattern := fmt.Sprintf("%s/%s/", logStreamPrefix, containerName)

--- a/internal/ecs/logs.go
+++ b/internal/ecs/logs.go
@@ -148,6 +148,7 @@ func TailLogGroups(ctx context.Context, cwClient *cloudwatchlogs.Client, logGrou
 		defer stream.Close()
 
 		eventsChan := stream.Events()
+
 		for {
 			select {
 			case <-ctx.Done():
@@ -183,11 +184,13 @@ func TailLogGroups(ctx context.Context, cwClient *cloudwatchlogs.Client, logGrou
 							"context", "CloudWatch logs live tail stream")
 						return
 					}
+
 					if event == nil {
 						slog.Debug(ErrStreamNilEvent,
 							"context", "CloudWatch logs live tail stream")
 						return
 					}
+
 					slog.Warn(ErrStreamUnexpectedEvent,
 						"event_type", fmt.Sprintf("%T", event),
 						"context", "CloudWatch logs live tail stream")

--- a/internal/ecs/logs.go
+++ b/internal/ecs/logs.go
@@ -36,7 +36,7 @@ const (
 	ErrStreamError = "log stream error occurred"
 )
 
-func getLogStreamPrefix(ctx context.Context, client *ecs.Client, taskDefinitionArn string) (logGroup, logStreamPrefix, containerName string, err error) {
+func getLogStreamPrefix(ctx context.Context, client *ecs.Client, taskDefinitionArn string) (string, string, string, error) {
 	resp, err := client.DescribeTaskDefinition(ctx, &ecs.DescribeTaskDefinitionInput{
 		TaskDefinition: &taskDefinitionArn,
 	})
@@ -53,7 +53,8 @@ func getLogStreamPrefix(ctx context.Context, client *ecs.Client, taskDefinitionA
 		return "", "", "", fmt.Errorf("container definition has no name in task %s", taskDefinitionArn)
 	}
 
-	containerName = *containerDef.Name
+	var logGroup, logStreamPrefix string
+	containerName := *containerDef.Name
 
 	logConfig := containerDef.LogConfiguration
 	if logConfig != nil && logConfig.LogDriver == ecsTypes.LogDriverAwslogs {

--- a/internal/ecs/logs.go
+++ b/internal/ecs/logs.go
@@ -147,7 +147,8 @@ func TailLogGroups(ctx context.Context, cwClient *cloudwatchlogs.Client, logGrou
 	go func() {
 		defer close(logChan)
 		defer func() {
-			if err := stream.Close(); err != nil {
+			err := stream.Close()
+			if err != nil {
 				slog.Error("failed to close CloudWatch logs stream",
 					"error", err,
 					"context", "CloudWatch logs live tail stream cleanup")
@@ -185,7 +186,8 @@ func TailLogGroups(ctx context.Context, cwClient *cloudwatchlogs.Client, logGrou
 						}
 					}
 				default:
-					if err := stream.Err(); err != nil {
+					err := stream.Err()
+					if err != nil {
 						slog.Error(ErrStreamError,
 							"error", err,
 							"context", "CloudWatch logs live tail stream")
@@ -209,7 +211,8 @@ func TailLogGroups(ctx context.Context, cwClient *cloudwatchlogs.Client, logGrou
 	}()
 
 	closeFunc := func() {
-		if err := stream.Close(); err != nil {
+		err := stream.Close()
+		if err != nil {
 			slog.Error("failed to close CloudWatch logs stream",
 				"error", err,
 				"context", "CloudWatch logs live tail stream manual close")

--- a/internal/ecs/prune.go
+++ b/internal/ecs/prune.go
@@ -57,6 +57,7 @@ func deregisterTaskFamily(ctx context.Context, family string, keepLast int, keep
 					Reason:  fmt.Sprintf("Failed to describe: %v", err),
 					Family:  family,
 				})
+
 				continue
 			}
 
@@ -68,6 +69,7 @@ func deregisterTaskFamily(ctx context.Context, family string, keepLast int, keep
 					Reason:  "Missing registration date",
 					Family:  family,
 				})
+
 				continue
 			}
 
@@ -83,6 +85,7 @@ func deregisterTaskFamily(ctx context.Context, family string, keepLast int, keep
 					Family:  family,
 				})
 				keep++
+
 				continue
 			}
 
@@ -94,6 +97,7 @@ func deregisterTaskFamily(ctx context.Context, family string, keepLast int, keep
 					Reason:  fmt.Sprintf("newer than %d days", keepDays),
 					Family:  family,
 				})
+
 				continue
 			}
 
@@ -110,6 +114,7 @@ func deregisterTaskFamily(ctx context.Context, family string, keepLast int, keep
 						Family:  family,
 					})
 					deleted-- // Decrement since it wasn't actually deleted
+
 					continue
 				}
 
@@ -139,6 +144,7 @@ func deregisterTaskFamily(ctx context.Context, family string, keepLast int, keep
 	}
 
 	skipped := totalCount - deleted - keep
+
 	return totalCount, deleted, skipped, processedTasks, nil
 }
 

--- a/internal/ecs/prune.go
+++ b/internal/ecs/prune.go
@@ -32,6 +32,7 @@ func deregisterTaskFamily(ctx context.Context, family string, keepLast int, keep
 	totalCount := 0
 	deleted := 0
 	keep := 0
+
 	var processedTasks []TaskDefinitionPruneEntry
 
 	for {

--- a/internal/ecs/restart.go
+++ b/internal/ecs/restart.go
@@ -95,6 +95,7 @@ func Restart(ctx context.Context, clients *AWSClients, cluster, service string, 
 
 	if kill {
 		result.Method = "kill"
+
 		stoppedTasks, err := stopAll(ctx, cluster, service, clients.ECS)
 		if err != nil {
 			return nil, fmt.Errorf("failed to stop tasks: %w", err)
@@ -102,6 +103,7 @@ func Restart(ctx context.Context, clients *AWSClients, cluster, service string, 
 		result.StoppedTasks = stoppedTasks
 	} else {
 		result.Method = "force_deploy"
+
 		serviceArn, taskDefinition, err := forceNewDeploy(ctx, cluster, service, clients.ECS)
 		if err != nil {
 			return nil, fmt.Errorf("failed to force new deployment: %w", err)

--- a/internal/ecs/restart.go
+++ b/internal/ecs/restart.go
@@ -27,7 +27,7 @@ func stopAll(ctx context.Context, cluster, service string, client *ecs.Client) (
 		ServiceName: &service,
 	})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to list tasks: %w", err)
 	}
 
 	var stoppedTasks []StoppedTaskInfo
@@ -72,7 +72,7 @@ func forceNewDeploy(ctx context.Context, cluster, service string, client *ecs.Cl
 	})
 
 	if err != nil {
-		return "", "", err
+		return "", "", fmt.Errorf("failed to update service: %w", err)
 	}
 
 	if output.Service == nil {

--- a/internal/ecs/revisions.go
+++ b/internal/ecs/revisions.go
@@ -29,7 +29,7 @@ func getFamilies(ctx context.Context, familyPrefix string, svc *ecs.Client) ([]s
 	})
 
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to list task definition families: %w", err)
 	}
 
 	return response.Families, nil
@@ -41,7 +41,7 @@ func getFamilyPrefix(ctx context.Context, cluster, service string, svc *ecs.Clie
 		Services: []string{service},
 	})
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to describe services: %w", err)
 	}
 
 	serviceInfo, err := utils.SafeGetFirstPtr(serviceResponse.Services, "no services found in response")
@@ -54,7 +54,7 @@ func getFamilyPrefix(ctx context.Context, cluster, service string, svc *ecs.Clie
 	})
 
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to describe task definition: %w", err)
 	}
 
 	if response.TaskDefinition.Family == nil {
@@ -76,7 +76,7 @@ func latestTaskDefinitionArn(ctx context.Context, cluster, service string, svc *
 	})
 
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to list task definitions: %w", err)
 	}
 
 	arn, err := utils.SafeGetFirst(response.TaskDefinitionArns, "no task definition ARNs found in response")
@@ -100,7 +100,7 @@ func getRevisions(ctx context.Context, familyPrefix string, lastRevisionsNr int,
 		response, err := svc.ListTaskDefinitions(ctx, definitionInput)
 
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to list task definitions: %w", err)
 		}
 
 		for _, def := range response.TaskDefinitionArns {

--- a/internal/ecs/utils.go
+++ b/internal/ecs/utils.go
@@ -15,10 +15,12 @@ func formatRunningTime(duration time.Duration) string {
 		days := totalHours / 24
 		hours := totalHours % 24
 		minutes := int(duration.Minutes()) % 60
+
 		return fmt.Sprintf("%dd %dh %dm", days, hours, minutes)
 	} else {
 		hours := totalHours
 		minutes := int(duration.Minutes()) % 60
+
 		return fmt.Sprintf("%dh %dm", hours, minutes)
 	}
 }

--- a/internal/utils/slice.go
+++ b/internal/utils/slice.go
@@ -24,6 +24,7 @@ func SafeGetFirstPtr[T any](slice []T, errorMsg string) (*T, error) {
 	if len(slice) == 0 {
 		return nil, errors.New(errorMsg)
 	}
+
 	return &slice[0], nil
 }
 
@@ -34,5 +35,6 @@ func SafeGetFirst[T any](slice []T, errorMsg string) (T, error) {
 	if len(slice) == 0 {
 		return zero, errors.New(errorMsg)
 	}
+
 	return slice[0], nil
 }


### PR DESCRIPTION
This PR:

- Refactors ECS commands to wrap returned errors with context for clearer diagnostics
- Adds a Makefile lint target and enables the gochecknoinits linter in .golangci.yml

Build passes locally.