### PR TITLE
Add CPU and memory override flags for run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,20 @@ runecs run "echo \"HELLO WORLD\"" -w --service mycanvas-ecs-staging-cluster/web
 
 **RunECS supports both AWS Fargate and EC2 capacity providers.** The tool automatically selects the appropriate launch type based on service configuration. When you use the `-w` flag, RunECS waits for task completion and streams full output to the terminal. This approach works well for interactive debugging and migration scripts.
 
+#### CPU and Memory Overrides
+
+One-off tasks often need different resources than the service defaults. A database migration might require more memory, while a lightweight health check needs far less CPU. Use the `--cpu` and `--memory` flags to override resource allocation per task without modifying the task definition:
+
+```bash
+# Run a memory-intensive migration with 4 GB of memory
+runecs run "bin/rails db:migrate" -w --memory 4GB --service mycanvas-ecs-staging-cluster/web
+
+# Run a CPU-intensive data export with 1024 CPU units
+runecs run "bin/export" -w --cpu 1024 --service mycanvas-ecs-staging-cluster/web
+```
+
+The `--cpu` (`-c`) flag accepts CPU units as integers (e.g., 256, 512, 1024). The `--memory` (`-m`) flag accepts values in MiB (e.g., 512, 1024) or with a GB suffix (e.g., 1GB, 2GB).
+
 ### Scale ECS Services
 
 Adjust the desired count of tasks for an ECS service instantly:

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -8,11 +8,13 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"strconv"
 	"syscall"
 
 	"github.com/buildkite/shellwords"
 	"github.com/spf13/cobra"
 	"runecs.io/v1/internal/ecs"
+	"runecs.io/v1/internal/utils"
 )
 
 func newRunCommand() *cobra.Command {
@@ -26,6 +28,8 @@ func newRunCommand() *cobra.Command {
 
 	cmd.PersistentFlags().BoolP("wait", "w", false, "wait for task to finish")
 	cmd.PersistentFlags().StringP("image-tag", "i", "", "docker image tag")
+	cmd.PersistentFlags().StringP("cpu", "c", "", "CPU override for task (e.g., 256, 512, 1024)")
+	cmd.PersistentFlags().StringP("memory", "m", "", "memory override for task (e.g., 512, 1024, 1GB, 2GB)")
 
 	return cmd
 }
@@ -69,12 +73,35 @@ func runHandler(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to get image-tag flag: %w", err)
 	}
 
+	cpuOverride, err := cmd.Flags().GetString("cpu")
+	if err != nil {
+		return fmt.Errorf("failed to get cpu flag: %w", err)
+	}
+
+	memoryOverride, err := cmd.Flags().GetString("memory")
+	if err != nil {
+		return fmt.Errorf("failed to get memory flag: %w", err)
+	}
+
+	// Validate that override values are numeric when provided
+	if cpuOverride != "" {
+		if _, err := strconv.Atoi(cpuOverride); err != nil {
+			return fmt.Errorf("invalid cpu value %q: must be a numeric string (e.g., 256, 512, 1024)", cpuOverride)
+		}
+	}
+	if memoryOverride != "" {
+		memoryOverride, err = utils.ParseMemory(memoryOverride)
+		if err != nil {
+			return err
+		}
+	}
+
 	parsedArgs, err := parseCommandArgs(args)
 	if err != nil {
 		return fmt.Errorf("error parsing command arguments: %w", err)
 	}
 
-	result, err := ecs.Execute(ctx, clients, cluster, service, parsedArgs, execWait, dockerImageTag)
+	result, err := ecs.Execute(ctx, clients, cluster, service, parsedArgs, execWait, dockerImageTag, cpuOverride, memoryOverride)
 	if err != nil {
 		return fmt.Errorf("failed to execute command: %w", err)
 	}
@@ -84,6 +111,14 @@ func runHandler(cmd *cobra.Command, args []string) error {
 		cmd.Printf("New task definition %s created\n", result.TaskDefinition)
 	} else {
 		cmd.Printf("Using task definition %s\n", result.TaskDefinition)
+	}
+
+	// Display resource overrides when applied
+	if cpuOverride != "" {
+		cmd.Printf("CPU override: %s\n", cpuOverride)
+	}
+	if memoryOverride != "" {
+		cmd.Printf("Memory override: %s MiB\n", memoryOverride)
 	}
 
 	cmd.Println()

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
-	"strconv"
 	"syscall"
 
 	"github.com/buildkite/shellwords"
@@ -85,8 +84,9 @@ func runHandler(cmd *cobra.Command, args []string) error {
 
 	// Validate that override values are numeric when provided
 	if cpuOverride != "" {
-		if _, err := strconv.Atoi(cpuOverride); err != nil {
-			return fmt.Errorf("invalid cpu value %q: must be a numeric string (e.g., 256, 512, 1024)", cpuOverride)
+		cpuOverride, err = utils.ParseCPU(cpuOverride)
+		if err != nil {
+			return err
 		}
 	}
 	if memoryOverride != "" {

--- a/internal/ecs/execute.go
+++ b/internal/ecs/execute.go
@@ -271,12 +271,18 @@ func Execute(ctx context.Context, clients *AWSClients, cluster, service string, 
 	// Task-level overrides use *string, container-level overrides use *int32.
 	if cpuOverride != "" {
 		taskOverride.Cpu = aws.String(cpuOverride)
-		cpuInt, _ := strconv.ParseInt(cpuOverride, 10, 32)
+		cpuInt, err := strconv.ParseInt(cpuOverride, 10, 32)
+		if err != nil {
+			return nil, fmt.Errorf("invalid cpu override value %q: %w", cpuOverride, err)
+		}
 		taskOverride.ContainerOverrides[0].Cpu = aws.Int32(int32(cpuInt))
 	}
 	if memoryOverride != "" {
 		taskOverride.Memory = aws.String(memoryOverride)
-		memInt, _ := strconv.ParseInt(memoryOverride, 10, 32)
+		memInt, err := strconv.ParseInt(memoryOverride, 10, 32)
+		if err != nil {
+			return nil, fmt.Errorf("invalid memory override value %q: %w", memoryOverride, err)
+		}
 		taskOverride.ContainerOverrides[0].Memory = aws.Int32(int32(memInt))
 	}
 

--- a/internal/ecs/execute.go
+++ b/internal/ecs/execute.go
@@ -17,8 +17,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
 	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
@@ -198,7 +200,7 @@ func waitForTaskCompletion(ctx context.Context, clients *AWSClients, cluster str
 	return nil
 }
 
-func Execute(ctx context.Context, clients *AWSClients, cluster, service string, cmd []string, waitForCompletion bool, dockerImageTag string) (*ExecuteResult, error) {
+func Execute(ctx context.Context, clients *AWSClients, cluster, service string, cmd []string, waitForCompletion bool, dockerImageTag string, cpuOverride, memoryOverride string) (*ExecuteResult, error) {
 	// Describe the service to get its configuration
 	resp, err := clients.ECS.DescribeServices(ctx, &ecs.DescribeServicesInput{
 		Cluster:  &cluster,
@@ -256,15 +258,32 @@ func Execute(ctx context.Context, clients *AWSClients, cluster, service string, 
 		taskDef = taskDefArn
 	}
 
+	containerOverride := types.ContainerOverride{
+		Name:    &tdef.Name,
+		Command: cmd,
+	}
+
+	taskOverride := &types.TaskOverride{
+		ContainerOverrides: []types.ContainerOverride{containerOverride},
+	}
+
+	// Apply CPU/memory overrides at both the task and container level.
+	// Task-level overrides use *string, container-level overrides use *int32.
+	if cpuOverride != "" {
+		taskOverride.Cpu = aws.String(cpuOverride)
+		cpuInt, _ := strconv.ParseInt(cpuOverride, 10, 32)
+		taskOverride.ContainerOverrides[0].Cpu = aws.Int32(int32(cpuInt))
+	}
+	if memoryOverride != "" {
+		taskOverride.Memory = aws.String(memoryOverride)
+		memInt, _ := strconv.ParseInt(memoryOverride, 10, 32)
+		taskOverride.ContainerOverrides[0].Memory = aws.Int32(int32(memInt))
+	}
+
 	runTaskInput := &ecs.RunTaskInput{
 		Cluster:        &cluster,
 		TaskDefinition: &taskDef,
-		Overrides: &types.TaskOverride{
-			ContainerOverrides: []types.ContainerOverride{{
-				Name:    &tdef.Name,
-				Command: cmd,
-			}},
-		},
+		Overrides:      taskOverride,
 	}
 
 	// Use CapacityProviderStrategy if available, otherwise use LaunchType

--- a/internal/utils/parse.go
+++ b/internal/utils/parse.go
@@ -1,0 +1,45 @@
+// Copyright (c) Petr Reichl and affiliates. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+const (
+	// mibPerGB converts gigabytes to mebibytes (AWS uses MiB for ECS memory)
+	mibPerGB = 1024
+)
+
+// ParseMemory converts a memory string to MiB.
+// Accepts plain numbers (treated as MiB) or suffixed values like "1GB", "2gb".
+func ParseMemory(value string) (string, error) {
+	lower := strings.ToLower(strings.TrimSpace(value))
+
+	if before, ok := strings.CutSuffix(lower, "gb"); ok {
+		gb, err := strconv.Atoi(before)
+		if err != nil {
+			return "", fmt.Errorf("invalid memory value %q: number before 'GB' must be an integer", value)
+		}
+		return strconv.Itoa(gb * mibPerGB), nil
+	}
+
+	if _, err := strconv.Atoi(lower); err != nil {
+		return "", fmt.Errorf("invalid memory value %q: must be a number in MiB or use GB suffix (e.g., 512, 1024, 1GB, 2GB)", value)
+	}
+
+	return value, nil
+}

--- a/internal/utils/parse.go
+++ b/internal/utils/parse.go
@@ -24,6 +24,20 @@ const (
 	mibPerGB = 1024
 )
 
+// ParseCPU validates a CPU override string.
+// Accepts positive integer strings representing CPU units (e.g., "256", "1024").
+func ParseCPU(value string) (string, error) {
+	trimmed := strings.TrimSpace(value)
+	cpu, err := strconv.Atoi(trimmed)
+	if err != nil {
+		return "", fmt.Errorf("invalid cpu value %q: must be a positive integer (e.g., 256, 512, 1024)", value)
+	}
+	if cpu <= 0 {
+		return "", fmt.Errorf("invalid cpu value %q: must be a positive integer (e.g., 256, 512, 1024)", value)
+	}
+	return trimmed, nil
+}
+
 // ParseMemory converts a memory string to MiB.
 // Accepts plain numbers (treated as MiB) or suffixed values like "1GB", "2gb".
 func ParseMemory(value string) (string, error) {
@@ -34,12 +48,19 @@ func ParseMemory(value string) (string, error) {
 		if err != nil {
 			return "", fmt.Errorf("invalid memory value %q: number before 'GB' must be an integer", value)
 		}
+		if gb <= 0 {
+			return "", fmt.Errorf("invalid memory value %q: must be a positive number (e.g., 512, 1024, 1GB, 2GB)", value)
+		}
 		return strconv.Itoa(gb * mibPerGB), nil
 	}
 
-	if _, err := strconv.Atoi(lower); err != nil {
+	mib, err := strconv.Atoi(lower)
+	if err != nil {
 		return "", fmt.Errorf("invalid memory value %q: must be a number in MiB or use GB suffix (e.g., 512, 1024, 1GB, 2GB)", value)
 	}
+	if mib <= 0 {
+		return "", fmt.Errorf("invalid memory value %q: must be a positive number (e.g., 512, 1024, 1GB, 2GB)", value)
+	}
 
-	return value, nil
+	return lower, nil
 }


### PR DESCRIPTION
## Summary
- Adds `--cpu`/`-c` and `--memory`/`-m` flags to the `run` command for overriding ECS task resource allocation at runtime
- Memory flag accepts plain MiB values (e.g., `512`, `1024`) or GB suffix (e.g., `1GB`, `2GB`), with automatic conversion to MiB
- Overrides apply at both ECS task and container level to ensure consistent resource allocation

## Test plan
- [ ] Run with `--cpu 512` and verify task uses overridden CPU
- [ ] Run with `--memory 2GB` and verify conversion to 2048 MiB
- [ ] Run with `--memory 1024` and verify plain MiB passthrough
- [ ] Run with invalid values (e.g., `--cpu abc`, `--memory foo`) and verify error messages
- [ ] Run without overrides and verify default behavior is unchanged